### PR TITLE
chore(deps): limit Dependabot open PRs to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## What
Set `open-pull-requests-limit: 1` on each Dependabot update entry (gradle, github-actions).

## Why
This repo requires branches to be up to date with `main` before they can be merged. When Dependabot opens several PRs at once, only one can be merged; the others must be rebased onto the new main, and the CI that already ran on them in parallel is wasted. Capping open PRs at 1 avoids that wasted CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)