### PR TITLE
ci: auto-merge Dependabot PRs after owner approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  merge_group:
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 jobs:
   format:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,13 @@
 name: Dependabot auto-merge
 
-on: pull_request
+# Turns on GitHub's native auto-merge for a Dependabot PR only after the repo
+# owner approves it. The approval is the gate: nothing merges without it. Once
+# enabled, branch protection still applies, so the PR merges only after the
+# required checks pass (and, with the merge queue enabled, after the queue
+# rebases and re-tests it against the latest main).
+on:
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: write
@@ -10,12 +17,13 @@ jobs:
   auto-merge:
     name: Auto-merge
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Only on an approving review, only for Dependabot's PRs, and only when the
+    # reviewer is a trusted member (guards public-repo reviews from outsiders).
+    if: >
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
     steps:
-      # Turns on GitHub's native auto-merge for the PR. Branch protection still
-      # applies, so the PR only merges once required checks pass and the required
-      # CODEOWNERS review is approved. With the merge queue enabled this enqueues
-      # the PR ("merge when ready") instead of merging immediately.
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,8 +3,8 @@ name: Dependabot auto-merge
 # Turns on GitHub's native auto-merge for a Dependabot PR only after the repo
 # owner approves it. The approval is the gate: nothing merges without it. Once
 # enabled, branch protection still applies, so the PR merges only after the
-# required checks pass (and, with the merge queue enabled, after the queue
-# rebases and re-tests it against the latest main).
+# required checks pass; if it falls behind main, Dependabot rebases it and CI
+# re-runs before it lands.
 on:
   pull_request_review:
     types: [submitted]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,6 @@
 name: Dependabot auto-merge
 
-# Turns on GitHub's native auto-merge for a Dependabot PR only after the repo
-# owner approves it. The approval is the gate: nothing merges without it. Once
-# enabled, branch protection still applies, so the PR merges only after the
-# required checks pass; if it falls behind main, Dependabot rebases it and CI
-# re-runs before it lands.
+# Enable auto-merge on a Dependabot PR once the owner approves it.
 on:
   pull_request_review:
     types: [submitted]
@@ -17,8 +13,7 @@ jobs:
   auto-merge:
     name: Auto-merge
     runs-on: ubuntu-latest
-    # Only on an approving review, only for Dependabot's PRs, and only when the
-    # reviewer is a trusted member (guards public-repo reviews from outsiders).
+    # author_association guards against outside-contributor approvals on public repos.
     if: >
       github.event.review.state == 'approved' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      # Turns on GitHub's native auto-merge for the PR. Branch protection still
+      # applies, so the PR only merges once required checks pass and the required
+      # CODEOWNERS review is approved. With the merge queue enabled this enqueues
+      # the PR ("merge when ready") instead of merging immediately.
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Add `.github/workflows/dependabot-auto-merge.yml` that enables GitHub's native auto-merge on a Dependabot PR **only after the repo owner approves it**.

## Behavior (trial variant: auto-merge on approval)
Dependabot opens a PR → nothing happens until you review. When **you approve**, the workflow turns on auto-merge → it merges once the required checks pass (Dependabot keeps its single PR rebased). Your **own** PRs are unaffected and need no review.

## Note
Merge queue turned out to be unavailable on personal-account repos, so the earlier `merge_group` trigger was removed — this PR is now just the auto-merge workflow. Combined with the Dependabot open-PR limit of 1, only one PR flows at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)